### PR TITLE
Jww vcr configure update

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   end
 
   root 'welcome#index'
+
   get 'tags/:tag', to: 'welcome#index', as: :tag
   get '/register', to: 'users#new'
 

--- a/spec/features/user/user_can_login_with_github_spec.rb
+++ b/spec/features/user/user_can_login_with_github_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 require 'rails_helper'
 
 RSpec.describe 'GET /auth/github/callback', type: :request do
@@ -27,8 +25,7 @@ RSpec.describe 'GET /auth/github/callback', type: :request do
   end
 
   describe 'When I view my dashboard' do
-    vcr_options = { record: :new_episodes }
-    it 'I can link my github account', :js, vcr: vcr_options do
+    it 'I can link my github account', :vcr do
       user = create(:user)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 

--- a/spec/features/user/user_can_see_github_followers_spec.rb
+++ b/spec/features/user/user_can_see_github_followers_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe 'As a user', type: :feature do
 
   describe 'When I view my dashboard' do
-    vcr_options = { :record => :new_episodes }
-    it 'I can see all of my github followers', :js, :vcr => vcr_options do
+    it 'I can see all of my github followers', :vcr do
 
       @user = create(:user, token: Figaro.env.github_personal_token)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
@@ -22,8 +21,7 @@ RSpec.describe 'As a user', type: :feature do
   end
 
   describe 'When I view my dashboard as a different user' do
-    vcr_options = { :record => :new_episodes }
-    it 'I can see all of my github followers', :js, :vcr => vcr_options do
+    it 'I can see all of my github followers', :vcr do
 
       @user2 = create(:user, token: Figaro.env.github_personal_token2)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user2)

--- a/spec/features/user/user_can_see_github_following_spec.rb
+++ b/spec/features/user/user_can_see_github_following_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe 'As a user', type: :feature do
 
   describe 'When I view my dashboard' do
-    vcr_options = { :record => :new_episodes }
-    it "I can see all the github profiles I'm following", :js, :vcr => vcr_options do
+    it "I can see all the github profiles I'm following", :vcr do
 
       @user = create(:user, token: Figaro.env.github_personal_token)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
@@ -22,8 +21,7 @@ RSpec.describe 'As a user', type: :feature do
   end
 
   describe 'When I view my dashboard as a different user' do
-    vcr_options = { :record => :new_episodes }
-    it "I can see all the github profiles I'm following", :js, :vcr => vcr_options do
+    it "I can see all the github profiles I'm following", :vcr do
 
       @user2 = create(:user, token: Figaro.env.github_personal_token2)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user2)

--- a/spec/features/user/user_can_see_github_repos_spec.rb
+++ b/spec/features/user/user_can_see_github_repos_spec.rb
@@ -3,8 +3,7 @@ require 'rails_helper'
 RSpec.describe 'As a user', type: :feature do
 
   describe 'When I view my dashboard' do
-    vcr_options = { :record => :new_episodes }
-    it 'I can see 5 of my GitHub repos listed', :js, :vcr => vcr_options do
+    it 'I can see 5 of my GitHub repos listed', :vcr do
 
       @user = create(:user, token: Figaro.env.github_personal_token)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
@@ -22,8 +21,7 @@ RSpec.describe 'As a user', type: :feature do
   end
 
   describe 'When I view my dashboard as a different user' do
-    vcr_options = { :record => :new_episodes }
-    it 'I can see 5 of my Github repos', :js, :vcr => vcr_options do
+    it 'I can see 5 of my Github repos', :vcr do
 
       @user2 = create(:user, token: Figaro.env.github_personal_token2)
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user2)

--- a/spec/features/user/user_email_activation_spec.rb
+++ b/spec/features/user/user_email_activation_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'As a guest user', type: :feature do
+  describe 'When I visit /' do
+    it 'I can link my github account' do
+
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ VCR.configure do |config|
   config.ignore_localhost = true
   config.cassette_library_dir = 'spec/cassettes'
   config.hook_into :webmock
+  config.default_cassette_options = { :record => :new_episodes, :erb => true }
   config.configure_rspec_metadata!
   config.filter_sensitive_data("<YOUTUBE_API_KEY>") { ENV['YOUTUBE_API_KEY'] }
   config.filter_sensitive_data("<github_personal_token>") { ENV['github_personal_token'] }


### PR DESCRIPTION
## Description

This PR updates the vcr configure block to include `new_episodes` and `erb: true` options. Known tests that include those options have been updated. Going forward it is no longer necessary to include them as options in individual tests.

## Type of change
- [ ] Bug fix
- [X] Refactor
- [ ] New feature
- [ ] Breaking change

## Notes

## RSpec results
```
......................................

Finished in 5.87 seconds (files took 1.36 seconds to load)
38 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/3module/projects/brownfield-of-dreams/coverage. 232 / 297 LOC (78.11%) covered.
```