### PR TITLE
jww_heroku_debug

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,5 +107,5 @@ Rails.application.configure do
     enable_starttls_auto: true
   }
   # Do not swallow errors in after_commit/after_rollback callbacks.
-  config.active_record.raise_in_transactional_callbacks = true
+  # config.active_record.raise_in_transactional_callbacks = true
 end


### PR DESCRIPTION
## Description

**Attempt to fix the Heroku deployment bug**
* When I ran `heroku run rails console --app pa-jw-brownfield-of-dreams ` I was able to see the following error:
  * `/app/vendor/bundle/ruby/2.4.0/gems/activerecord-5.2.4.1/lib/active_record/dynamic_matchers.rb:22:in `method_missing': undefined method `raise_in_transactional_callbacks=' for ActiveRecord::Base:Class (NoMethodError)`

## Type of change
- [X] Bug fix
- [ ] Refactor
- [ ] New feature
- [ ] Breaking change

## Notes

I'm not sure if this will fix the production bug, however it's as specific of an error that I could find when searching the Heroku Rails Console.

## RSpec results
```
...........................................

Finished in 8 seconds (files took 1.3 seconds to load)
43 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/3module/projects/brownfield-of-dreams/coverage. 306 / 352 LOC (86.93%) covered.
```