### PR TITLE
Jww heroku email activation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
     user = User.create(user_params)
     if user.save
       session[:user_id] = user.id
-      AccountActivationMailer.inform(user).deliver_now
+      AccountActivationMailer.inform(user, request.url).deliver_now
       flash[:success] = 'Please check your email to activate account.'
       redirect_to dashboard_path
     else

--- a/app/mailers/account_activation_mailer.rb
+++ b/app/mailers/account_activation_mailer.rb
@@ -1,6 +1,7 @@
 class AccountActivationMailer < ApplicationMailer
-  def inform(new_user)
+  def inform(new_user, url)
     @user = new_user
+    @url = url
     mail(to: @user.email, subject: "#{@user.first_name}: Please activate your account!")
   end
 end

--- a/app/views/account_activation_mailer/inform.html.erb
+++ b/app/views/account_activation_mailer/inform.html.erb
@@ -1,3 +1,3 @@
 <h4>Hey <%= @user.first_name  %>,</h4>
 <p>Thank you for creating an account with Turing Tutorials! Welcome to the community!</p>
-<p>Please activate your account <%= link_to 'Acitvate Now', "http://localhost:3000/users/activate?confirm=#{(@user.confirm_token)}" %></p>
+<p>Please activate your account <%= link_to 'Acitvate Now', "#{@url}/activate?confirm=#{(@user.confirm_token)}" %></p>

--- a/app/views/account_activation_mailer/inform.text.erb
+++ b/app/views/account_activation_mailer/inform.text.erb
@@ -1,3 +1,3 @@
 Hey <%= @user.first_name  %>,
 Thank you for creating an account with Turing Tutorials! Welcome to the community!
-Please activate your account <%= link_to 'Acitvate Now', "http://localhost:3000/users/activate?confirm=#{(@user.confirm_token)}" %>
+Please activate your account <%= link_to 'Acitvate Now', "#{@url}/activate?confirm=#{(@user.confirm_token)}" %>


### PR DESCRIPTION
## Description

The PR continues to address Heroku bugs
* Updated email authentication links to now be dynamic
  * When the mailer is instantiated it now is passed `request.url`
    * `request.url` is set to an instance variable `@url` which is used to create the link where a user is sent when they click `Activate Now`

## Type of change
- [X] Bug fix
- [X] Refactor
- [ ] New feature
- [ ] Breaking change

## Notes

##RSpec results
```
...........................................

Finished in 7.49 seconds (files took 2.81 seconds to load)
43 examples, 0 failures

Coverage report generated for RSpec to /Users/jww/turing/3module/projects/brownfield-of-dreams/coverage. 307 / 353 LOC (86.97%) covered.
```
